### PR TITLE
Allow generated IDL files

### DIFF
--- a/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
@@ -128,6 +128,10 @@ set(target_dependencies
 foreach(dep ${target_dependencies})
   if(NOT EXISTS "${dep}")
     message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+    get_property(is_generated SOURCE "${dep}" PROPERTY GENERATED)
+    if(NOT ${_is_generated})
+      message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+    endif()
   endif()
 endforeach()
 

--- a/rosidl_typesupport_opensplice_cpp/cmake/rosidl_typesupport_opensplice_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_cpp/cmake/rosidl_typesupport_opensplice_cpp_generate_interfaces.cmake
@@ -149,7 +149,10 @@ set(target_dependencies
   ${_dependency_files})
 foreach(dep ${target_dependencies})
   if(NOT EXISTS "${dep}")
-    message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+    get_property(is_generated SOURCE "${dep}" PROPERTY GENERATED)
+    if(NOT ${_is_generated})
+      message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+    endif()
   endif()
 endforeach()
 


### PR DESCRIPTION
The target dependency won't exist at cmake configure time before the first build if it is generated, so don't `FATAL_ERROR` in that case.

connects to ros2/rcl_interfaces#47