### PR TITLE
Replace more srv with @(subfolder)

### DIFF
--- a/rosidl_typesupport_opensplice_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_opensplice_c/resource/srv__type_support_c.cpp.em
@@ -50,9 +50,9 @@ extern "C"
 
 // forward declare type support functions
 const rosidl_message_type_support_t *
-  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_opensplice_c, @(spec.pkg_name), srv, @(spec.srv_name)_Request)();
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_opensplice_c, @(spec.pkg_name), @(subfolder), @(spec.srv_name)_Request)();
 const rosidl_message_type_support_t *
-  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_opensplice_c, @(spec.pkg_name), srv, @(spec.srv_name)_Response)();
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_opensplice_c, @(spec.pkg_name), @(subfolder), @(spec.srv_name)_Response)();
 
 const char *
 register_types__@(subfolder)__@(spec.srv_name)(
@@ -106,7 +106,7 @@ send_request__@(subfolder)__@(spec.srv_name)(
 
   SampleT request;
   const rosidl_message_type_support_t * ts =
-    ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_opensplice_c, @(spec.pkg_name), srv, @(spec.srv_name)_Request)();
+    ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_opensplice_c, @(spec.pkg_name), @(subfolder), @(spec.srv_name)_Request)();
   const message_type_support_callbacks_t * callbacks =
     static_cast<const message_type_support_callbacks_t *>(ts->data);
   callbacks->convert_ros_to_dds(untyped_ros_request, static_cast<void *>(&request.data()));
@@ -147,7 +147,7 @@ take_request__@(subfolder)__@(spec.srv_name)(
 
   if (*taken) {
     const rosidl_message_type_support_t * ts =
-      ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_opensplice_c, @(spec.pkg_name), srv, @(spec.srv_name)_Request)();
+      ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_opensplice_c, @(spec.pkg_name), @(subfolder), @(spec.srv_name)_Request)();
     const message_type_support_callbacks_t * callbacks =
       static_cast<const message_type_support_callbacks_t *>(ts->data);
     callbacks->convert_dds_to_ros(static_cast<void *>(&request.data()), untyped_ros_request);
@@ -173,7 +173,7 @@ send_response__@(subfolder)__@(spec.srv_name)(
 {
   rosidl_typesupport_opensplice_cpp::Sample<@(__dds_msg_type_prefix)_Response_> response;
   const rosidl_message_type_support_t * ts =
-    ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_opensplice_c, @(spec.pkg_name), srv, @(spec.srv_name)_Response)();
+    ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_opensplice_c, @(spec.pkg_name), @(subfolder), @(spec.srv_name)_Response)();
   const message_type_support_callbacks_t * callbacks =
     static_cast<const message_type_support_callbacks_t *>(ts->data);
   callbacks->convert_ros_to_dds(untyped_ros_response, static_cast<void *>(&response.data()));
@@ -211,7 +211,7 @@ take_response__@(subfolder)__@(spec.srv_name)(
     request_header->sequence_number = response.sequence_number_;
 
     const rosidl_message_type_support_t * ts =
-      ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_opensplice_c, @(spec.pkg_name), srv, @(spec.srv_name)_Response)();
+      ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_opensplice_c, @(spec.pkg_name), @(subfolder), @(spec.srv_name)_Response)();
     const message_type_support_callbacks_t * callbacks =
       static_cast<const message_type_support_callbacks_t *>(ts->data);
     callbacks->convert_dds_to_ros(


### PR DESCRIPTION
Services can be generated in either an `srv` or an `action` namespace. There were a few places here that still had `srv` hardcoded in the C symbol names.

This should fix the packaging job failures described at https://github.com/ros2/rcl_interfaces/pull/47#issuecomment-437939685