### PR TITLE
add opensplice support for cdr serialization

### DIFF
--- a/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.em
@@ -597,7 +597,7 @@ serialize(
 
 static const char *
 deserialize(
-  const char * buffer,
+  const uint8_t * buffer,
   unsigned length,
   void * untyped_ros_message)
 {

--- a/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.em
@@ -25,6 +25,7 @@
 #include <limits>
 
 #include <u_instanceHandle.h>
+#include <CdrTypeSupport.h>
 
 // Provides the rosidl_typesupport_opensplice_c__identifier symbol declaration.
 #include "rosidl_typesupport_opensplice_c/identifier.h"
@@ -32,6 +33,7 @@
 // Provides the definition of the message_type_support_callbacks_t struct.
 #include "rosidl_typesupport_opensplice_cpp/message_type_support.h"
 #include "rosidl_typesupport_opensplice_cpp/u__instanceHandle.h"
+#include "rmw/rmw.h"
 
 #include "@(pkg)/msg/rosidl_typesupport_opensplice_c__visibility_control.h"
 @{header_file_name = get_header_filename_from_msg_name(type)}@
@@ -96,6 +98,8 @@ __dds_msg_type_prefix = "{0}::{1}::dds_::{2}_".format(
 using __dds_msg_type = @(__dds_msg_type_prefix);
 using __ros_msg_type = @(pkg)__@(subfolder)__@(type);
 
+static @(__dds_msg_type_prefix)TypeSupport _type_support;
+
 static const char *
 register_type(void * untyped_participant, const char * type_name)
 {
@@ -108,8 +112,7 @@ register_type(void * untyped_participant, const char * type_name)
   using DDS::DomainParticipant;
   DomainParticipant * participant = static_cast<DomainParticipant *>(untyped_participant);
 
-  @(__dds_msg_type_prefix)TypeSupport type_support;
-  DDS::ReturnCode_t status = type_support.register_type(participant, type_name);
+  DDS::ReturnCode_t status = _type_support.register_type(participant, type_name);
   switch (status) {
     case DDS::RETCODE_ERROR:
       return "@(__dds_msg_type_prefix)TypeSupport.register_type: "
@@ -525,6 +528,115 @@ finally:
 
   return errs;
 }
+
+static const char *
+serialize(
+  const void * untyped_ros_message,
+  void * untyped_serialized_data)
+{
+  if (!untyped_ros_message) {
+    return "ros message handle is null";
+  }
+  if (!untyped_serialized_data) {
+    return "serialized_data handle is null";
+  }
+
+  __dds_msg_type dds_message;
+  const char * err_msg = convert_ros_to_dds(untyped_ros_message, &dds_message);
+  if (err_msg != 0) {
+    return err_msg;
+  }
+
+  DDS::OpenSplice::CdrTypeSupport cdr_ts(_type_support);
+
+  DDS::OpenSplice::CdrSerializedData * serdata = nullptr;
+
+  DDS::ReturnCode_t status = cdr_ts.serialize(&dds_message, &serdata);
+  switch (status) {
+    case DDS::RETCODE_ERROR:
+      return "@(__dds_msg_type_prefix)TypeSupport.serialize: "
+             "an internal error has occurred";
+    case DDS::RETCODE_BAD_PARAMETER:
+      return "@(__dds_msg_type_prefix)TypeSupport.serialize: "
+             "bad parameter";
+    case DDS::RETCODE_ALREADY_DELETED:
+      return "@(__dds_msg_type_prefix)TypeSupport.serialize: "
+             "this @(__dds_msg_type_prefix)TypeSupport has already been deleted";
+    case DDS::RETCODE_OUT_OF_RESOURCES:
+      return "@(__dds_msg_type_prefix)TypeSupport.serialize: "
+             "out of resources";
+    case DDS::RETCODE_OK:
+      break;
+    default:
+      return "@(__dds_msg_type_prefix)TypeSupport.serialize failed with "
+             "unknown return code";
+  }
+
+  rmw_serialized_message_t * serialized_data =
+    static_cast<rmw_serialized_message_t *>(untyped_serialized_data);
+
+  auto data_length = serdata->get_size();
+
+  if (serialized_data->buffer_capacity < data_length) {
+    if (rmw_serialized_message_resize(serialized_data, data_length) == RMW_RET_OK) {
+      serialized_data->buffer_capacity = data_length;
+    } else {
+      delete serdata;
+      return "@(__dds_msg_type_prefix)TypeSupport.serialize: "
+             "unable to dynamically resize serialized message";
+    }
+  }
+
+  serialized_data->buffer_length = data_length;
+  serdata->get_data(serialized_data->buffer);
+
+  delete serdata;
+
+  return nullptr;
+}
+
+static const char *
+deserialize(
+  const char * buffer,
+  unsigned length,
+  void * untyped_ros_message)
+{
+  const char * errs = nullptr;
+
+  if (untyped_ros_message == 0) {
+    return "invalid ros message pointer";
+  }
+
+  DDS::OpenSplice::CdrTypeSupport cdr_ts(_type_support);
+
+  __dds_msg_type dds_message;
+  DDS::ReturnCode_t status = cdr_ts.deserialize(buffer, length, &dds_message);
+
+  switch (status) {
+    case DDS::RETCODE_ERROR:
+      return "@(__dds_msg_type_prefix)TypeSupport.deserialize: "
+             "an internal error has occurred";
+    case DDS::RETCODE_BAD_PARAMETER:
+      return "@(__dds_msg_type_prefix)TypeSupport.deserialize: "
+             "bad parameter";
+    case DDS::RETCODE_ALREADY_DELETED:
+      return "@(__dds_msg_type_prefix)TypeSupport.deserialize: "
+             "this @(__dds_msg_type_prefix)TypeSupport has already been deleted";
+    case DDS::RETCODE_OUT_OF_RESOURCES:
+      return "@(__dds_msg_type_prefix)TypeSupport.deserialize: "
+             "out of resources";
+    case DDS::RETCODE_OK:
+      break;
+    default:
+      return "@(__dds_msg_type_prefix)TypeSupport.deserialize failed with "
+             "unknown return code";
+  }
+
+  errs = convert_dds_to_ros(&dds_message, untyped_ros_message);
+
+  return errs;
+}
+
 @
 @# // Collect the callback functions and provide a function to get the type support struct.
 
@@ -534,6 +646,8 @@ static message_type_support_callbacks_t __callbacks = {
   register_type,  // register_type
   publish,  // publish
   take,  // take
+  serialize,  // serialize message
+  deserialize,  // deserialize message
   convert_ros_to_dds,  // convert_ros_to_dds
   convert_dds_to_ros,  // convert_dds_to_ros
 };

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/message_type_support.h
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/message_type_support.h
@@ -16,6 +16,7 @@
 #define ROSIDL_TYPESUPPORT_OPENSPLICE_CPP__MESSAGE_TYPE_SUPPORT_H_
 
 #include <stdbool.h>
+#include <ccpp.h>
 
 #include "rosidl_generator_c/message_type_support_struct.h"
 
@@ -41,6 +42,15 @@ typedef struct message_type_support_callbacks_t
     void * ros_message,
     bool * taken,
     void * sending_publication_handle);
+  const char *
+  (*serialize)(
+    const void * ros_message,
+    void * untyped_serialized_message);
+  const char *
+  (*deserialize)(
+    const char * buffer,
+    unsigned length,
+    void * ros_message);
   // Functions for converting between DDS and ROS messages of this type.
   // Returns NULL if successful, otherwise an error string.
   const char *

--- a/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/message_type_support.h
+++ b/rosidl_typesupport_opensplice_cpp/include/rosidl_typesupport_opensplice_cpp/message_type_support.h
@@ -48,7 +48,7 @@ typedef struct message_type_support_callbacks_t
     void * untyped_serialized_message);
   const char *
   (*deserialize)(
-    const char * buffer,
+    const uint8_t * buffer,
     unsigned length,
     void * ros_message);
   // Functions for converting between DDS and ROS messages of this type.

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__rosidl_typesupport_opensplice_cpp.hpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__rosidl_typesupport_opensplice_cpp.hpp.em
@@ -75,6 +75,20 @@ extern bool take__@(spec.base_type.type)(
   void * untyped_ros_message,
   bool * taken);
 
+ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT_@(spec.base_type.pkg_name)
+const char *
+serialize__@(spec.base_type.type)(
+  const void * untyped_ros_message,
+  void * serialized_data);
+
+ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT_@(spec.base_type.pkg_name)
+const char *
+deserialize__@(spec.base_type.type)(
+  const char * buffer,
+  unsigned length,
+  void * untyped_ros_message);
+
+
 }  // namespace typesupport_opensplice_cpp
 
 }  // namespace @(subfolder)

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__rosidl_typesupport_opensplice_cpp.hpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__rosidl_typesupport_opensplice_cpp.hpp.em
@@ -84,7 +84,7 @@ serialize__@(spec.base_type.type)(
 ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT_@(spec.base_type.pkg_name)
 const char *
 deserialize__@(spec.base_type.type)(
-  const char * buffer,
+  const uint8_t * buffer,
   unsigned length,
   void * untyped_ros_message);
 

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
@@ -20,6 +20,7 @@
 #include <stdexcept>
 
 #include <u_instanceHandle.h>
+#include <CdrTypeSupport.h>
 
 #include "rosidl_typesupport_cpp/message_type_support.hpp"
 
@@ -29,6 +30,8 @@
 #include "rosidl_typesupport_opensplice_cpp/message_type_support.h"
 #include "rosidl_typesupport_opensplice_cpp/message_type_support_decl.hpp"
 #include "rosidl_typesupport_opensplice_cpp/u__instanceHandle.h"
+#include "rmw/rmw.h"
+
 
 // forward declaration of message dependencies and their conversion functions
 @[for field in spec.fields]@
@@ -72,6 +75,8 @@ __dds_msg_type_prefix = "{}::{}::dds_::{}_".format(
 using __dds_msg_type = @(__dds_msg_type_prefix);
 using __ros_msg_type = @(spec.base_type.pkg_name)::@(subfolder)::@(spec.base_type.type);
 
+static @(__dds_msg_type_prefix)TypeSupport __type_support;
+
 ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT_@(spec.base_type.pkg_name)
 const char *
 register_type__@(spec.base_type.type)(
@@ -87,8 +92,7 @@ register_type__@(spec.base_type.type)(
   DDS::DomainParticipant * participant =
     static_cast<DDS::DomainParticipant *>(untyped_participant);
 
-  @(__dds_msg_type_prefix)TypeSupport type_support;
-  DDS::ReturnCode_t status = type_support.register_type(participant, type_name);
+  DDS::ReturnCode_t status = __type_support.register_type(participant, type_name);
   switch (status) {
     case DDS::RETCODE_ERROR:
       return "@(__dds_msg_type_prefix)TypeSupport.register_type: "
@@ -368,12 +372,111 @@ finally:
   return errs;
 }
 
+ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT_@(spec.base_type.pkg_name)
+const char *
+serialize__@(spec.base_type.type)(
+  const void * untyped_ros_message,
+  void * untyped_serialized_data)
+{
+  const __ros_msg_type & ros_message = *static_cast<const __ros_msg_type *>(untyped_ros_message);
+  __dds_msg_type dds_message;
+
+  convert_ros_message_to_dds(ros_message, dds_message);
+
+  DDS::OpenSplice::CdrTypeSupport cdr_ts(__type_support);
+  DDS::OpenSplice::CdrSerializedData * serdata = nullptr;
+
+  DDS::ReturnCode_t status = cdr_ts.serialize(&dds_message, &serdata);
+  switch (status) {
+    case DDS::RETCODE_ERROR:
+      return "@(__dds_msg_type_prefix)TypeSupport.serialize: "
+             "an internal error has occurred";
+    case DDS::RETCODE_BAD_PARAMETER:
+      return "@(__dds_msg_type_prefix)TypeSupport.serialize: "
+             "bad parameter";
+    case DDS::RETCODE_ALREADY_DELETED:
+      return "@(__dds_msg_type_prefix)TypeSupport.serialize: "
+             "this @(__dds_msg_type_prefix)TypeSupport has already been deleted";
+    case DDS::RETCODE_OUT_OF_RESOURCES:
+      return "@(__dds_msg_type_prefix)TypeSupport.serialize: "
+             "out of resources";
+    case DDS::RETCODE_OK:
+      break;
+    default:
+      return "@(__dds_msg_type_prefix)TypeSupport.serialize failed with "
+             "unknown return code";
+  }
+
+  rmw_serialized_message_t * serialized_data =
+    static_cast<rmw_serialized_message_t *>(untyped_serialized_data);
+
+  auto data_length = serdata->get_size();
+
+  if (serialized_data->buffer_capacity < data_length) {
+    if (rmw_serialized_message_resize(serialized_data, data_length) == RMW_RET_OK) {
+      serialized_data->buffer_capacity = data_length;
+    } else {
+      delete serdata;
+      return "@(__dds_msg_type_prefix)TypeSupport.serialize: "
+             "unable to dynamically resize serialized message";
+    }
+  }
+
+  serialized_data->buffer_length = data_length;
+  serdata->get_data(serialized_data->buffer);
+
+  delete serdata;
+
+  return nullptr;
+}
+
+ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT_@(spec.base_type.pkg_name)
+const char *
+deserialize__@(spec.base_type.type)(
+  const char * buffer,
+  unsigned length,
+  void * untyped_ros_message)
+{
+  __dds_msg_type dds_message;
+
+  DDS::OpenSplice::CdrTypeSupport cdr_ts(__type_support);
+
+  DDS::ReturnCode_t status = cdr_ts.deserialize(buffer, length, &dds_message);
+
+  switch (status) {
+    case DDS::RETCODE_ERROR:
+      return "@(__dds_msg_type_prefix)TypeSupport.deserialize: "
+             "an internal error has occurred";
+    case DDS::RETCODE_BAD_PARAMETER:
+      return "@(__dds_msg_type_prefix)TypeSupport.deserialize: "
+             "bad parameter";
+    case DDS::RETCODE_ALREADY_DELETED:
+      return "@(__dds_msg_type_prefix)TypeSupport.deserialize: "
+             "this @(__dds_msg_type_prefix)TypeSupport has already been deleted";
+    case DDS::RETCODE_OUT_OF_RESOURCES:
+      return "@(__dds_msg_type_prefix)TypeSupport.deserialize: "
+             "out of resources";
+    case DDS::RETCODE_OK:
+      break;
+    default:
+      return "@(__dds_msg_type_prefix)TypeSupport.deserialize failed with "
+             "unknown return code";
+  }
+
+  __ros_msg_type & ros_message = *static_cast<__ros_msg_type *>(untyped_ros_message);
+  convert_dds_message_to_ros(dds_message, ros_message);
+
+  return nullptr;
+}
+
 static message_type_support_callbacks_t callbacks = {
   "@(spec.base_type.pkg_name)",
   "@(spec.base_type.type)",
   &register_type__@(spec.base_type.type),
   &publish__@(spec.base_type.type),
   &take__@(spec.base_type.type),
+  &serialize__@(spec.base_type.type),
+  &deserialize__@(spec.base_type.type),
   nullptr,  // convert ros to dds (handled differently for C++)
   nullptr,  // convert dds to ros (handled differently for C++)
 };

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
@@ -433,7 +433,7 @@ serialize__@(spec.base_type.type)(
 ROSIDL_TYPESUPPORT_OPENSPLICE_CPP_EXPORT_@(spec.base_type.pkg_name)
 const char *
 deserialize__@(spec.base_type.type)(
-  const char * buffer,
+  const uint8_t * buffer,
   unsigned length,
   void * untyped_ros_message)
 {


### PR DESCRIPTION
The latest opensource OpenSplice release has been updated with support for cdr serialization. These changes update rosidl_typesupport_opensplice to use this functionality.