### PR TITLE
Increase the MaxAutoParticipantIndex for opensplice to 99.

### DIFF
--- a/opensplice_cmake_module/config/ros_ospl.xml
+++ b/opensplice_cmake_module/config/ros_ospl.xml
@@ -21,5 +21,13 @@
             <!-- the following one is necessary only for TwinOaks CoreDX DDS compatibility -->
             <!-- <ExplicitlyPublishQosSetToDefault>true</ExplicitlyPublishQosSetToDefault> -->
         </Compatibility>
+        <Discovery>
+             <!-- By default, OpenSplice only allows up to 9 participants (see
+                  http://download.prismtech.com/docs/Vortex/html/ospl/ConfGuide/guide.html#maxautoparticipantindex)
+                  This means that only 9 nodes can be run at a time, which even
+                  moderately complex robots easily achieve.
+             -->
+            <MaxAutoParticipantIndex>99</MaxAutoParticipantIndex>
+        </Discovery>
     </DDSI2Service>
 </OpenSplice>

--- a/opensplice_cmake_module/config/ros_ospl.xml
+++ b/opensplice_cmake_module/config/ros_ospl.xml
@@ -22,11 +22,11 @@
             <!-- <ExplicitlyPublishQosSetToDefault>true</ExplicitlyPublishQosSetToDefault> -->
         </Compatibility>
         <Discovery>
-             <!-- By default, OpenSplice only allows up to 9 participants (see
-                  http://download.prismtech.com/docs/Vortex/html/ospl/ConfGuide/guide.html#maxautoparticipantindex)
-                  This means that only 9 nodes can be run at a time, which even
-                  moderately complex robots easily achieve.
-             -->
+            <!-- By default, OpenSplice only allows up to 9 participants per
+                 machine (see http://download.prismtech.com/docs/Vortex/html/ospl/ConfGuide/guide.html#maxautoparticipantindex)
+                 This means that only 9 nodes can be run on a given machine,
+                 which even moderately complex robots easily achieve.
+            -->
             <MaxAutoParticipantIndex>99</MaxAutoParticipantIndex>
         </Discovery>
     </DDSI2Service>


### PR DESCRIPTION
From code inspection on OpenSplice 6.9 20181126, there are two minor downsides to increasing this:

1.  Slightly slower startup time since the code iterates over every participant index up to the max to find a free one (see https://github.com/ADLINK-IST/opensplice/blob/OSPL_V6_9_181126OSS_RELEASE/src/services/ddsi2e/core/q_init.c#L890)
1.  Slightly slower port choosing when non-multicast addresses are in use, again because of iterating over every participant index (see https://github.com/ADLINK-IST/opensplice/blob/OSPL_V6_9_181126OSS_RELEASE/src/services/ddsi2e/core/q_addrset.c#L93)

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>