### PR TITLE
add option to idlpp to maintain the include file namespace

### DIFF
--- a/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
+++ b/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
@@ -26,23 +26,19 @@ from rosidl_parser import validate_field_types
 
 
 def check_idlpp_supports_include_namespaces(idl_pp):
-    res = 0
+    res = False
 
     r = subprocess.getstatusoutput(idl_pp + ' -v')
     ospl_version = r[1].split(':')[1].strip()
+    m = re.search('([1-9][0-9]*\.[0-9]+)\.([0-9]*)', ospl_version)
+    if m and m.lastindex == 2:
+        major = m.group(1)
+        minor = m.group(2)
 
     if ospl_version.endswith('OSS'):
-        m = re.search('([1-9][0-9]*\.[0-9]+)\.([0-9]*)', ospl_version)
-        if m and m.lastindex == 2:
-            major = m.group(1)
-            minor = m.group(2)
-            res = (major > '6.9' or (major == '6.9' and minor > '181127'))
+        res = (major > '6.9' or (major == '6.9' and minor > '181127'))
     else:
-        m = re.search('([1-9][0-9]*\.[0-9]+)\.([0-9]*)', ospl_version)
-        if m and m.lastindex == 2:
-            major = m.group(1)
-            minor = m.group(2)
-            res = (major > '6.10' or (major == '6.10' and minor > '1'))
+        res = (major > '6.10' or (major == '6.10' and minor > '1'))
 
     return res
 

--- a/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
+++ b/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
@@ -24,29 +24,28 @@ from rosidl_parser import parse_message_file
 from rosidl_parser import parse_service_file
 from rosidl_parser import validate_field_types
 
+
 def check_idlpp_supports_include_namespaces(idl_pp):
     res = 0
 
-    try:
-        r = subprocess.getstatusoutput(idl_pp + ' -v')
-        ospl_version = r[1].split(':')[1].strip()
+    r = subprocess.getstatusoutput(idl_pp + ' -v')
+    ospl_version = r[1].split(':')[1].strip()
 
-        if ospl_version.endswith('OSS'):
-            m = re.search('([1-9][0-9]*\.[0-9]+)\.([0-9]*)', ospl_version)
-            if m and m.lastindex == 2:
-                major = m.group(1)
-                minor = m.group(2)
-                res = (major > '6.9' or (major == '6.9' and minor > '181127'))
-        else:
-            m = re.search('([1-9][0-9]*\.[0-9]+)\.([0-9]*)', ospl_version)
-            if m and m.lastindex == 2:
-                major = m.group(1)
-                minor = m.group(2)
-                res = (major > '6.10' or (major == '6.10' and minor > '1'))
-    except:
-        pass
+    if ospl_version.endswith('OSS'):
+        m = re.search('([1-9][0-9]*\.[0-9]+)\.([0-9]*)', ospl_version)
+        if m and m.lastindex == 2:
+            major = m.group(1)
+            minor = m.group(2)
+            res = (major > '6.9' or (major == '6.9' and minor > '181127'))
+    else:
+        m = re.search('([1-9][0-9]*\.[0-9]+)\.([0-9]*)', ospl_version)
+        if m and m.lastindex == 2:
+            major = m.group(1)
+            minor = m.group(2)
+            res = (major > '6.10' or (major == '6.10' and minor > '1'))
 
     return res
+
 
 def generate_dds_opensplice_cpp(
     pkg_name, dds_interface_files, dds_interface_base_path, deps, output_basepath, idl_pp

--- a/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
+++ b/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import os
-import subprocess
 import re
+import subprocess
 
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 from rosidl_cmake import expand_template
@@ -31,7 +31,7 @@ def check_idlpp_supports_include_namespaces(idl_pp):
 
     r = subprocess.getstatusoutput(idl_pp + ' -v')
     ospl_version = r[1].split(':')[1].strip()
-    m = re.search('([1-9][0-9]*)\.([0-9]+)\.([0-9]*)', ospl_version)
+    m = re.search(r'([1-9][0-9]*)\.([0-9]+)\.([0-9]*)', ospl_version)
     if m and m.lastindex == 3:
         major = int(m.group(1))
         minor = int(m.group(2))

--- a/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
+++ b/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
@@ -26,8 +26,6 @@ from rosidl_parser import validate_field_types
 
 
 def check_idlpp_supports_include_namespaces(idl_pp):
-    res = False
-
     r = subprocess.getstatusoutput(idl_pp + ' -v')
     ospl_version = r[1].split(':')[1].strip()
     m = re.search('([1-9][0-9]*\.[0-9]+)\.([0-9]*)', ospl_version)
@@ -36,11 +34,9 @@ def check_idlpp_supports_include_namespaces(idl_pp):
         minor = m.group(2)
 
     if ospl_version.endswith('OSS'):
-        res = (major > '6.9' or (major == '6.9' and minor > '181127'))
+        return major > '6.9' or (major == '6.9' and minor > '181127')
     else:
-        res = (major > '6.10' or (major == '6.10' and minor > '1'))
-
-    return res
+        return major > '6.10' or (major == '6.10' and minor > '1')
 
 
 def generate_dds_opensplice_cpp(

--- a/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
+++ b/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
@@ -26,21 +26,22 @@ from rosidl_parser import validate_field_types
 
 
 def check_idlpp_supports_include_namespaces(idl_pp):
-    res = False
+    version = 0
+    build = 0
 
     r = subprocess.getstatusoutput(idl_pp + ' -v')
     ospl_version = r[1].split(':')[1].strip()
-    m = re.search('([1-9][0-9]*\.[0-9]+)\.([0-9]*)', ospl_version)
-    if m and m.lastindex == 2:
-        major = m.group(1)
-        minor = m.group(2)
+    m = re.search('([1-9][0-9]*)\.([0-9]+)\.([0-9]*)', ospl_version)
+    if m and m.lastindex == 3:
+        major = int(m.group(1))
+        minor = int(m.group(2))
+        build = int(m.group(3))
+        version = major * 100 + minor
 
     if ospl_version.endswith('OSS'):
-        res = (major > '6.9' or (major == '6.9' and minor > '181127'))
+        return version > 609 or (version == 609 and build > 190226)
     else:
-        res = (major > '6.10' or (major == '6.10' and minor > '1'))
-
-    return res
+        return version > 610 or (version == 610 and build > 1)
 
 
 def generate_dds_opensplice_cpp(


### PR DESCRIPTION
Depending on the version of OpenSplice add the -o maintain-include-namespace option to idlpp to enable preservation of the include path names in the for the idl generated files.