### PR TITLE
bump OpenSplice version and use -o maintain-include-namespace

### DIFF
--- a/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_c/cmake/rosidl_typesupport_opensplice_c_generate_interfaces.cmake
@@ -148,12 +148,6 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_opensplice_c
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_opensplice_cpp
-  "${_output_path}/msg/dds_opensplice_c"
-  "${_dds_output_path}/msg/dds_opensplice"
-  "${_output_path}/srv/dds_opensplice_c"
-  "${_dds_output_path}/srv/dds_opensplice_c"
-  "${_output_path}/action/dds_opensplice_c"
-  "${_dds_output_path}/action/dds_opensplice_c"
 )
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   "rmw"

--- a/rosidl_typesupport_opensplice_c/package.xml
+++ b/rosidl_typesupport_opensplice_c/package.xml
@@ -8,14 +8,14 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>libopensplice69</buildtool_depend>
+  <buildtool_depend version_gte="6.9.190403">libopensplice69</buildtool_depend>
   <buildtool_depend>opensplice_cmake_module</buildtool_depend>
   <buildtool_depend>rosidl_cmake</buildtool_depend>
   <buildtool_depend>rosidl_generator_c</buildtool_depend>
   <buildtool_depend>rosidl_typesupport_opensplice_cpp</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
-  <buildtool_export_depend>libopensplice69</buildtool_export_depend>
+  <buildtool_export_depend version_gte="6.9.190403">libopensplice69</buildtool_export_depend>
   <buildtool_export_depend>opensplice_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_c</buildtool_export_depend>

--- a/rosidl_typesupport_opensplice_cpp/cmake/rosidl_typesupport_opensplice_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_opensplice_cpp/cmake/rosidl_typesupport_opensplice_cpp_generate_interfaces.cmake
@@ -177,9 +177,6 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_opensplice_cpp
-  "${_output_path}/msg/dds_opensplice"
-  "${_output_path}/srv/dds_opensplice"
-  "${_output_path}/action/dds_opensplice"
 )
 ament_target_dependencies(
   ${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_typesupport_opensplice_cpp/package.xml
+++ b/rosidl_typesupport_opensplice_cpp/package.xml
@@ -8,14 +8,14 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>libopensplice69</buildtool_depend>
+  <buildtool_depend version_gte="6.9.190403">libopensplice69</buildtool_depend>
   <buildtool_depend>opensplice_cmake_module</buildtool_depend>
   <buildtool_depend>rosidl_cmake</buildtool_depend>
   <buildtool_depend>rosidl_generator_c</buildtool_depend>
   <buildtool_depend>rosidl_generator_cpp</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
-  <buildtool_export_depend>libopensplice69</buildtool_export_depend>
+  <buildtool_export_depend version_gte="6.9.190403">libopensplice69</buildtool_export_depend>
   <buildtool_export_depend>opensplice_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_c</buildtool_export_depend>

--- a/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
+++ b/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
@@ -13,29 +13,9 @@
 # limitations under the License.
 
 import os
-import re
 import subprocess
 
 from rosidl_cmake import generate_files
-
-
-def check_idlpp_supports_include_namespaces(idl_pp):
-    version = 0
-    build = 0
-
-    output = subprocess.check_output([idl_pp, '-v'])
-    ospl_version = output.decode().split(':')[1].strip()
-    m = re.search(r'([1-9][0-9]*)\.([0-9]+)\.([0-9]*)', ospl_version)
-    if m and m.lastindex == 3:
-        major = int(m.group(1))
-        minor = int(m.group(2))
-        build = int(m.group(3))
-        version = major * 100 + minor
-
-    if ospl_version.endswith('OSS'):
-        return version > 609 or (version == 609 and build > 190403)
-    else:
-        return version > 610 or (version == 610 and build > 1)
 
 
 def generate_dds_opensplice_cpp(
@@ -76,16 +56,12 @@ def generate_dds_opensplice_cpp(
         cmd = [idl_pp]
         for include_dir in include_dirs:
             cmd += ['-I', include_dir]
-        if check_idlpp_supports_include_namespaces(idl_pp):
-            cmd += [
-                '-o',
-                'maintain-include-namespace'
-            ]
         cmd += [
             '-S',
             '-l', 'cpp',
             '-N',
             '-d', output_path,
+            '-o', 'maintain-include-namespace',
             filename
         ]
         if os.name == 'nt':


### PR DESCRIPTION
While #20 targets Crystal in a backward compatible way this patch requires the newer version of OpenSplice.