### PR TITLE
remove assert on missing comment

### DIFF
--- a/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
+++ b/rosidl_typesupport_opensplice_cpp/rosidl_typesupport_opensplice_cpp/__init__.py
@@ -111,8 +111,6 @@ def _replace_path_and_timestamp(lines, msg_name, idl_path):
             assert found_source, "No '// Source: ' line was found before"
             lines[i] = '//  Generated: timestamp removed to make the build reproducible'
             break
-    else:
-        assert False, "Failed to find '// Generated: ' line"
     return lines
 
 


### PR DESCRIPTION
The changes to the OpenSplice idlpp pre-processor may no longer generate the // Generated comment in the generated files. Therefor this is assert is no valid.