### PR TITLE
Change AllowMulticast to spdp

### DIFF
--- a/opensplice_cmake_module/config/ros_ospl.xml
+++ b/opensplice_cmake_module/config/ros_ospl.xml
@@ -10,7 +10,10 @@
     <DDSI2Service name="ddsi2">
         <General>
             <NetworkInterfaceAddress>AUTO</NetworkInterfaceAddress>
-            <AllowMulticast>true</AllowMulticast>
+            <!-- On wireless networks, multicast traffic can severely limit effective bandwidth,
+                 so enable it only for participant discovery.
+            -->
+            <AllowMulticast>spdp</AllowMulticast>
             <EnableMulticastLoopback>true</EnableMulticastLoopback>
             <CoexistWithNativeNetworking>false</CoexistWithNativeNetworking>
             <FragmentSize>64000B</FragmentSize>


### PR DESCRIPTION
In my testing, topics with reliable durability across a wifi network can only sustain about 30-60 messages per second (on a Ubiquiti AC Pro Router). Disabling multicast allows 800-1000 messages per second.