### PR TITLE
[Backport] Fix some comparisons with a sign mismatch

### DIFF
--- a/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_opensplice_c/resource/msg__type_support_c.cpp.em
@@ -204,7 +204,7 @@ convert_ros_to_dds_@(__ros_msg_type_prefix)(const void * untyped_ros_message, vo
     size_t size = @(member.type.size);
 @[    else]@
     size_t size = ros_message->@(member.name).size;
-    if (size > (std::numeric_limits<DDS::Long>::max)()) {
+    if (size > static_cast<size_t>((std::numeric_limits<DDS::Long>::max)())) {
       return "array size exceeds maximum DDS sequence size";
     }
     DDS::Long length = static_cast<DDS::Long>(size);

--- a/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_opensplice_cpp/resource/msg__type_support.cpp.em
@@ -148,7 +148,7 @@ convert_ros_message_to_dds(
     size_t size = @(member.type.size);
 @[    else]@
     size_t size = ros_message.@(member.name).size();
-    if (size > (std::numeric_limits<DDS::Long>::max)()) {
+    if (size > static_cast<size_t>((std::numeric_limits<DDS::Long>::max)())) {
       throw std::runtime_error("array size exceeds maximum DDS sequence size");
     }
     DDS::Long length = static_cast<DDS::Long>(size);


### PR DESCRIPTION
This is a backport of #32 for Dashing.

---
Resolves build warnings due to `-Wsign-compare` with GCC 9.