### PR TITLE
Add fallback logic in case AMENT_CURRENT_PREFIX is not set

### DIFF
--- a/opensplice_cmake_module/env_hook/opensplice.sh.in
+++ b/opensplice_cmake_module/env_hook/opensplice.sh.in
@@ -33,6 +33,16 @@ else
   _OSPL_HOME_TO_USE=$OSPL_HOME
 fi
 
+# TODO(jacobperron): Find a better solution that does not rely on colcon
+# if AMENT_CURRENT_PREFIX is not set, fall back to destination set at configure time
+if [ ! -d "$AMENT_CURRENT_PREFIX" ]; then
+  if [ -z "$COLCON_CURRENT_PREFIX" ]; then
+    echo "The compile time prefix path '$AMENT_CURRENT_PREFIX' doesn't " \
+      "exist. Consider sourcing a different extension than '.sh'." 1>&2
+  else
+    AMENT_CURRENT_PREFIX="$COLCON_CURRENT_PREFIX"
+  fi
+fi
 
 _DEFAULT_OSPL_URI="file://$AMENT_CURRENT_PREFIX/share/opensplice_cmake_module/config/ros_ospl.xml"
 

--- a/opensplice_cmake_module/env_hook/opensplice.sh.in
+++ b/opensplice_cmake_module/env_hook/opensplice.sh.in
@@ -34,7 +34,7 @@ else
 fi
 
 # TODO(jacobperron): Find a better solution that does not rely on colcon
-# if AMENT_CURRENT_PREFIX is not set, fall back to destination set at configure time
+# if AMENT_CURRENT_PREFIX is not set, try to use COLCON_CURRENT_PREFIX if available
 if [ ! -d "$AMENT_CURRENT_PREFIX" ]; then
   if [ -z "$COLCON_CURRENT_PREFIX" ]; then
     echo "The compile time prefix path '$AMENT_CURRENT_PREFIX' doesn't " \


### PR DESCRIPTION
This is more of a temporary fix, since it would be better to not rely on colcon.

Fixes ros2/rmw_opensplice#283.
