### PR TITLE
Allow specific network interface.

### DIFF
--- a/opensplice_cmake_module/config/ros_ospl.xml
+++ b/opensplice_cmake_module/config/ros_ospl.xml
@@ -9,7 +9,7 @@
     </Domain>
     <DDSI2Service name="ddsi2">
         <General>
-            <NetworkInterfaceAddress>AUTO</NetworkInterfaceAddress>
+            <NetworkInterfaceAddress>${OSPL_NETWORK_INTERFACE:-AUTO}</NetworkInterfaceAddress>
             <!-- On wireless networks, multicast traffic can severely limit effective bandwidth,
                  so enable it only for participant discovery.
             -->


### PR DESCRIPTION
This allows specific network interface by setting the ```OSPL_NETWORK_INTERFACE``` environment variable.

This is related to the issue https://github.com/ros2/rmw_opensplice/issues/296 and https://github.com/ros2/rmw_opensplice/pull/297.